### PR TITLE
Bump TextCopy from 5.0.2 to 6.1.0

### DIFF
--- a/src/Karata.Web/Karata.Web.csproj
+++ b/src/Karata.Web/Karata.Web.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="MudBlazor" Version="6.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
-    <PackageReference Include="TextCopy" Version="5.0.2" />
+    <PackageReference Include="TextCopy" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR hopes to fix #14 by upgrading to the most recent version of [TextCopy](https://nuget.org/packages/TextCopy/).