### PR TITLE
Combine individual card movements

### DIFF
--- a/src/Karata.Client/Infrastructure/State/RoomState.cs
+++ b/src/Karata.Client/Infrastructure/State/RoomState.cs
@@ -9,17 +9,6 @@ public class RoomState(RoomData data, string username, ILoggerFactory? logging =
 {
     public HandData MyHand => State.Game.Hands.Single(h => h.User.Email == username);
 
-    public record AddCardRangeToPile(List<Card> Cards) : StateAction<RoomData>
-    {
-        public override RoomData Apply(RoomData state)
-        {
-            var pile = state.Game.Pile;
-            foreach (var card in Cards) pile.Push(card);
-
-            return state with { Game = state.Game with { Pile = pile } };
-        }
-    }
-
     public record AddHandToRoom(UserData User) : StateAction<RoomData>
     {
         public override RoomData Apply(RoomData state)
@@ -70,6 +59,23 @@ public class RoomState(RoomData data, string username, ILoggerFactory? logging =
         }
     }
 
+    public record MoveCardsFromHandToPile(UserData User, List<Card> Cards, bool Mine) : StateAction<RoomData>
+    {
+        public override RoomData Apply(RoomData state)
+        {
+            var hands = Mine switch
+            {
+                true => state.Game.Hands.Select(h => h.User == User ? h with { Cards = h.Cards.Except(Cards).ToList() } : h),
+                false => state.Game.Hands.Select(h => h.User == User ? h with { Cards = h.Cards[Cards.Count..] } : h)
+            };
+            
+            var pile = state.Game.Pile;
+            foreach (var card in Cards) pile.Push(card);
+
+            return state with { Game = state.Game with { Hands = hands.ToList(), Pile = pile } };
+        }
+    }
+
     public record ReceiveChat(ChatData Chat) : StateAction<RoomData>
     {
         public override RoomData Apply(RoomData state) => state with { Chats = state.Chats.Append(Chat).ToList() };
@@ -86,26 +92,6 @@ public class RoomState(RoomData data, string username, ILoggerFactory? logging =
             {
                 Game = state.Game with { Pile = pile, DeckCount = state.Game.DeckCount + cards.Count }
             };
-        }
-    }
-
-    public record RemoveCardsFromPlayerHand(UserData User, int Count) : StateAction<RoomData>
-    {
-        public override RoomData Apply(RoomData state)
-        {
-            var hands = state.Game.Hands
-                .Select(h => h.User == User ? h with { Cards = h.Cards[Count..] } : h);
-            return state with { Game = state.Game with { Hands = hands.ToList() } };
-        }
-    }
-
-    public record RemoveCardRangeFromHand(HandData Hand, List<Card> Cards) : StateAction<RoomData>
-    {
-        public override RoomData Apply(RoomData state)
-        {
-            var cards = Hand.Cards.Except(Cards).ToList();
-            var hands = state.Game.Hands.Select(h => h.User == Hand.User ? Hand with { Cards = cards } : h);
-            return state with { Game = state.Game with { Hands = hands.ToList() } };
         }
     }
 

--- a/src/Karata.Client/Infrastructure/State/RoomState.cs
+++ b/src/Karata.Client/Infrastructure/State/RoomState.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Karata.Cards;
 using Karata.Pebble;
 using Karata.Pebble.StateActions;
@@ -57,6 +56,20 @@ public class RoomState(RoomData data, string username, ILoggerFactory? logging =
         }
     }
 
+    public record MoveCardsFromDeckToPile(List<Card> Cards) : StateAction<RoomData>
+    {
+        public override RoomData Apply(RoomData state)
+        {
+            var pile = state.Game.Pile;
+            foreach (var card in Cards) pile.Push(card);
+
+            return state with
+            {
+                Game = state.Game with { DeckCount = state.Game.DeckCount - Cards.Count, Pile = pile }
+            };
+        }
+    }
+
     public record ReceiveChat(ChatData Chat) : StateAction<RoomData>
     {
         public override RoomData Apply(RoomData state) => state with { Chats = state.Chats.Append(Chat).ToList() };
@@ -73,14 +86,6 @@ public class RoomState(RoomData data, string username, ILoggerFactory? logging =
             {
                 Game = state.Game with { Pile = pile, DeckCount = state.Game.DeckCount + cards.Count }
             };
-        }
-    }
-
-    public record RemoveCardsFromDeck(int Count) : StateAction<RoomData>
-    {
-        public override RoomData Apply(RoomData state)
-        {
-            return state with { Game = state.Game with { DeckCount = state.Game.DeckCount - Count } };
         }
     }
 

--- a/src/Karata.Client/Infrastructure/State/RoomState.cs
+++ b/src/Karata.Client/Infrastructure/State/RoomState.cs
@@ -10,25 +10,6 @@ public class RoomState(RoomData data, string username, ILoggerFactory? logging =
 {
     public HandData MyHand => State.Game.Hands.Single(h => h.User.Email == username);
 
-    public record AddCardsToPlayerHand(UserData User, int Count) : StateAction<RoomData>
-    {
-        public override RoomData Apply(RoomData state)
-        {
-            var hands = state.Game.Hands.
-                Select(h => h.User == User ? h with { Cards = [..h.Cards, ..Enumerable.Repeat(new Card(), Count)] } : h);
-            return state with { Game = state.Game with { Hands = hands.ToList() } };
-        }
-    }
-
-    public record AddCardRangeToHand(UserData User, List<Card> Cards) : StateAction<RoomData>
-    {
-        public override RoomData Apply(RoomData state)
-        {
-            var hands = state.Game.Hands.Select(h => h.User == User ? h with { Cards = [..h.Cards, ..Cards] } : h);
-            return state with { Game = state.Game with { Hands = hands.ToList() } };
-        }
-    }
-
     public record AddCardRangeToPile(List<Card> Cards) : StateAction<RoomData>
     {
         public override RoomData Apply(RoomData state)
@@ -46,6 +27,33 @@ public class RoomState(RoomData data, string username, ILoggerFactory? logging =
         {
             var hand = new HandData { User = User, Cards = [] };
             return state with { Game = state.Game with { Hands = [..state.Game.Hands, hand] } };
+        }
+    }
+
+    public record MoveCardCountFromDeckToHand(UserData User, int Count) : StateAction<RoomData>
+    {
+        public override RoomData Apply(RoomData state)
+        {
+            var hands = state.Game.Hands.
+                Select(h => h.User == User ? h with { Cards = [..h.Cards, ..Enumerable.Repeat(new Card(), Count)] } : h);
+            return state with
+            {
+                Game = state.Game with { Hands = hands.ToList(), DeckCount = state.Game.DeckCount - Count }
+            };
+        }
+    }
+    
+    public record MoveCardsFromDeckToHand(UserData User, List<Card> Cards) : StateAction<RoomData>
+    {
+        public override RoomData Apply(RoomData state)
+        {
+            var hands = state.Game.Hands
+                .Select(h => h.User == User ? h with { Cards = [..h.Cards, ..Cards] } : h);
+
+            return state with
+            {
+                Game = state.Game with { Hands = hands.ToList(), DeckCount = state.Game.DeckCount - Cards.Count }
+            };
         }
     }
 

--- a/src/Karata.Client/Pages/Play.razor
+++ b/src/Karata.Client/Pages/Play.razor
@@ -165,8 +165,6 @@
             .WithStatefulReconnect()
             .AddJsonProtocol()
             .Build();
-        
-        _hub.On<List<Card>>("AddCardRangeToPile", cards => _store!.Mutate(new RoomState.AddCardRangeToPile(cards)));
 
         _hub.On<UserData>("AddHandToRoom", user =>
         {
@@ -192,6 +190,8 @@
         _hub.On<List<Card>>("MoveCardsFromDeckToHand", cards => _store!.Mutate(new RoomState.MoveCardsFromDeckToHand(_store!.MyHand.User, cards)));
 
         _hub.On<List<Card>>("MoveCardsFromDeckToPile", cards => _store!.Mutate(new RoomState.MoveCardsFromDeckToPile(cards)));
+
+        _hub.On<UserData, List<Card>>("MoveCardsFromHandToPile", (user, cards) => _store!.Mutate(new RoomState.MoveCardsFromHandToPile(user, cards, _store!.MyHand.User == user)));
         
         _hub.On("NotifyTurnProcessed", () =>
         {
@@ -237,11 +237,7 @@
         });
 
         _hub.On("ReclaimPile", () => _store!.Mutate(new RoomState.ReclaimPile()));
-
-        _hub.On<UserData, int>("RemoveCardsFromPlayerHand", (user, num) => _store!.Mutate(new RoomState.RemoveCardsFromPlayerHand(user, num)));
-
-        _hub.On<List<Card>>("RemoveCardRangeFromHand", cards => _store!.Mutate(new RoomState.RemoveCardRangeFromHand(_store!.MyHand, cards)));
-
+        
         _hub.On("RemoveFromRoom", () =>
         {
             _store!.Forget(OnStoreChanged);

--- a/src/Karata.Client/Pages/Play.razor
+++ b/src/Karata.Client/Pages/Play.razor
@@ -191,6 +191,8 @@
 
         _hub.On<List<Card>>("MoveCardsFromDeckToHand", cards => _store!.Mutate(new RoomState.MoveCardsFromDeckToHand(_store!.MyHand.User, cards)));
 
+        _hub.On<List<Card>>("MoveCardsFromDeckToPile", cards => _store!.Mutate(new RoomState.MoveCardsFromDeckToPile(cards)));
+        
         _hub.On("NotifyTurnProcessed", () =>
         {
             _turn.Clear();
@@ -235,9 +237,6 @@
         });
 
         _hub.On("ReclaimPile", () => _store!.Mutate(new RoomState.ReclaimPile()));
-
-        // TODO: Remove after fixing top card 
-        _hub.On<int>("RemoveCardsFromDeck", num => _store!.Mutate(new RoomState.RemoveCardsFromDeck(num)));
 
         _hub.On<UserData, int>("RemoveCardsFromPlayerHand", (user, num) => _store!.Mutate(new RoomState.RemoveCardsFromPlayerHand(user, num)));
 

--- a/src/Karata.Client/Pages/Play.razor
+++ b/src/Karata.Client/Pages/Play.razor
@@ -165,11 +165,7 @@
             .WithStatefulReconnect()
             .AddJsonProtocol()
             .Build();
-
-        _hub.On<UserData, int>("AddCardsToPlayerHand", (user, num) => _store!.Mutate(new RoomState.AddCardsToPlayerHand(user, num)));
-
-        _hub.On<List<Card>>("AddCardRangeToHand", cards => _store!.Mutate(new RoomState.AddCardRangeToHand(_store!.MyHand.User, cards)));
-
+        
         _hub.On<List<Card>>("AddCardRangeToPile", cards => _store!.Mutate(new RoomState.AddCardRangeToPile(cards)));
 
         _hub.On<UserData>("AddHandToRoom", user =>
@@ -190,6 +186,10 @@
 
         // TODO: This is an implicit client disconnect, meaning the cleanup logic is in OnDisconnectedAsync. Review this. 
         _hub.On("EndGame", () => Navigator.NavigateTo($"/game/{_store!.State.Id.ToString()}/over"));
+        
+        _hub.On<UserData, int>("MoveCardCountFromDeckToHand", (user, num) => _store!.Mutate(new RoomState.MoveCardCountFromDeckToHand(user, num)));
+
+        _hub.On<List<Card>>("MoveCardsFromDeckToHand", cards => _store!.Mutate(new RoomState.MoveCardsFromDeckToHand(_store!.MyHand.User, cards)));
 
         _hub.On("NotifyTurnProcessed", () =>
         {
@@ -236,6 +236,7 @@
 
         _hub.On("ReclaimPile", () => _store!.Mutate(new RoomState.ReclaimPile()));
 
+        // TODO: Remove after fixing top card 
         _hub.On<int>("RemoveCardsFromDeck", num => _store!.Mutate(new RoomState.RemoveCardsFromDeck(num)));
 
         _hub.On<UserData, int>("RemoveCardsFromPlayerHand", (user, num) => _store!.Mutate(new RoomState.RemoveCardsFromPlayerHand(user, num)));

--- a/src/Karata.Server/Hubs/Clients/IGameClient.cs
+++ b/src/Karata.Server/Hubs/Clients/IGameClient.cs
@@ -4,8 +4,13 @@ namespace Karata.Server.Hubs.Clients;
 
 public interface IGameClient
 {
+    // Adds another user to the current room
     Task AddHandToRoom(UserData user);
+    
+    // Adds the current user to a room
     Task AddToRoom(RoomData room);
+    
+    // Ends the game
     Task EndGame();
     
     // Moves n cards from deck to another player's hand. 
@@ -20,15 +25,36 @@ public interface IGameClient
     // Moves cards from hand to the pile. 
     Task MoveCardsFromHandToPile(UserData user, List<Card> cards);
 
+    // Notifies the current user's client that the turn has been processed - so the UI can clean up and state.
     Task NotifyTurnProcessed();
+    
+    // Prompts for the user to select a card request.
     Task<Card?> PromptCardRequest(bool specific);
+    
+    // Prompts the user to declare last card status
     Task<bool> PromptLastCardRequest();
+    
+    // Receives a chat message sent by another player.
     Task ReceiveChat(ChatData message);
+    
+    // Receives a system message.
     Task ReceiveSystemMessage(SystemMessage message);
+    
+    // Reclaims the pile and adds cards to the deck
     Task ReclaimPile();
+    
+    // Removes the current player from the room
     Task RemoveFromRoom();
+    
+    // Removes another player from the room
     Task RemoveHandFromRoom(UserData user);
+    
+    // Sets the current card request
     Task SetCurrentRequest(Card? request);
+    
+    // Updates the game status
     Task UpdateGameStatus(GameStatus status);
+    
+    // Updates the current turn
     Task UpdateTurn(int turn);
 }

--- a/src/Karata.Server/Hubs/Clients/IGameClient.cs
+++ b/src/Karata.Server/Hubs/Clients/IGameClient.cs
@@ -4,7 +4,7 @@ namespace Karata.Server.Hubs.Clients;
 
 public interface IGameClient
 {
-    Task AddCardRangeToPile(List<Card> cards);
+    [Obsolete] Task AddCardRangeToPile(List<Card> cards);
     Task AddHandToRoom(UserData user);
     Task AddToRoom(RoomData room);
     Task EndGame();
@@ -14,6 +14,9 @@ public interface IGameClient
     
     // Moves cards from deck to current player's hand.
     Task MoveCardsFromDeckToHand(List<Card> cards);
+    
+    // Moves cards from deck to the pile. 
+    Task MoveCardsFromDeckToPile(List<Card> cards);
 
     Task NotifyTurnProcessed();
     Task<Card?> PromptCardRequest(bool specific);
@@ -21,7 +24,6 @@ public interface IGameClient
     Task ReceiveChat(ChatData message);
     Task ReceiveSystemMessage(SystemMessage message);
     Task ReclaimPile();
-    [Obsolete] Task RemoveCardsFromDeck(int num);
     Task RemoveCardRangeFromHand(List<Card> cards);
     Task RemoveCardsFromPlayerHand(UserData user, int num);
     Task RemoveFromRoom();

--- a/src/Karata.Server/Hubs/Clients/IGameClient.cs
+++ b/src/Karata.Server/Hubs/Clients/IGameClient.cs
@@ -4,19 +4,21 @@ namespace Karata.Server.Hubs.Clients;
 
 public interface IGameClient
 {
-    [Obsolete] Task AddCardRangeToPile(List<Card> cards);
     Task AddHandToRoom(UserData user);
     Task AddToRoom(RoomData room);
     Task EndGame();
     
     // Moves n cards from deck to another player's hand. 
-    Task MoveCardCountFromDeckToHand(UserData hand, int num);
+    Task MoveCardCountFromDeckToHand(UserData user, int num);
     
     // Moves cards from deck to current player's hand.
     Task MoveCardsFromDeckToHand(List<Card> cards);
     
     // Moves cards from deck to the pile. 
     Task MoveCardsFromDeckToPile(List<Card> cards);
+    
+    // Moves cards from hand to the pile. 
+    Task MoveCardsFromHandToPile(UserData user, List<Card> cards);
 
     Task NotifyTurnProcessed();
     Task<Card?> PromptCardRequest(bool specific);
@@ -24,8 +26,6 @@ public interface IGameClient
     Task ReceiveChat(ChatData message);
     Task ReceiveSystemMessage(SystemMessage message);
     Task ReclaimPile();
-    Task RemoveCardRangeFromHand(List<Card> cards);
-    Task RemoveCardsFromPlayerHand(UserData user, int num);
     Task RemoveFromRoom();
     Task RemoveHandFromRoom(UserData user);
     Task SetCurrentRequest(Card? request);

--- a/src/Karata.Server/Hubs/Clients/IGameClient.cs
+++ b/src/Karata.Server/Hubs/Clients/IGameClient.cs
@@ -1,23 +1,27 @@
-using System.Collections.Immutable;
 using Karata.Shared.Models;
 
 namespace Karata.Server.Hubs.Clients;
 
 public interface IGameClient
 {
-    Task AddCardsToPlayerHand(UserData user, int num);
-    Task AddCardRangeToHand(List<Card> cards); 
     Task AddCardRangeToPile(List<Card> cards);
     Task AddHandToRoom(UserData user);
     Task AddToRoom(RoomData room);
     Task EndGame();
+    
+    // Moves n cards from deck to another player's hand. 
+    Task MoveCardCountFromDeckToHand(UserData hand, int num);
+    
+    // Moves cards from deck to current player's hand.
+    Task MoveCardsFromDeckToHand(List<Card> cards);
+
     Task NotifyTurnProcessed();
     Task<Card?> PromptCardRequest(bool specific);
     Task<bool> PromptLastCardRequest();
     Task ReceiveChat(ChatData message);
     Task ReceiveSystemMessage(SystemMessage message);
     Task ReclaimPile();
-    Task RemoveCardsFromDeck(int num);
+    [Obsolete] Task RemoveCardsFromDeck(int num);
     Task RemoveCardRangeFromHand(List<Card> cards);
     Task RemoveCardsFromPlayerHand(UserData user, int num);
     Task RemoveFromRoom();

--- a/src/Karata.Server/Services/GameStartService.cs
+++ b/src/Karata.Server/Services/GameStartService.cs
@@ -63,9 +63,8 @@ public class GameStartService(
         var top = deck.Deal();
         logger.LogDebug("Top card is {Card}.", top);
 
-        await Everyone.RemoveCardsFromDeck(1);
         game.Pile.Push(top);
-        await Everyone.AddCardRangeToPile([top]);
+        await Everyone.MoveCardsFromDeckToPile([top]);
 
         logger.LogDebug("Start dealing cards to {Count} players.", game.Hands.Count);
 

--- a/src/Karata.Server/Services/GameStartService.cs
+++ b/src/Karata.Server/Services/GameStartService.cs
@@ -70,18 +70,15 @@ public class GameStartService(
         logger.LogDebug("Start dealing cards to {Count} players.", game.Hands.Count);
 
         // Deal player cards
-        // TODO: Explicit card movements (Deck -> Hand, Hand -> Pile, Pile -> Deck).
-        // Needs more thought: will have to restructure PerformTurn
         foreach (var hand in game.Hands)
         {
             var dealt = deck.DealMany(DealCount);
-            await Everyone.RemoveCardsFromDeck(DealCount);
 
             logger.LogDebug("Dealing {Count} cards to {User}. Cards: {Cards}.", DealCount, hand.Player.UserName, string.Join(", ", dealt));
 
             hand.Cards.AddRange(dealt);
-            await Hand(hand).AddCardRangeToHand(dealt);
-            await Hands(room.Game.HandsExceptPlayerId(hand.Player.Id)).AddCardsToPlayerHand(hand.Player.ToData(), DealCount);
+            await Hand(hand).MoveCardsFromDeckToHand(dealt);
+            await Hands(room.Game.HandsExceptPlayerId(hand.Player.Id)).MoveCardCountFromDeckToHand(hand.Player.ToData(), DealCount);
         }
 
         logger.LogDebug("Finished dealing cards.");

--- a/src/Karata.Server/Services/TurnProcessingService.cs
+++ b/src/Karata.Server/Services/TurnProcessingService.cs
@@ -47,7 +47,7 @@ public class TurnProcessingService(
             await DetermineCardRequest(room, turn);
             ApplyTurnDelta(room, turn);
 
-            await NotifyClientsOfGameState(room, player, turn);
+            await NotifyClientsOfGameState(player, turn);
             await EnsurePendingCardsPicked(room);
             await CheckRemainingCards(room, player, turn);
 
@@ -122,12 +122,10 @@ public class TurnProcessingService(
         (room.Game.Give, room.Game.Pick) = (turn.Delta.Give, turn.Delta.Pick);
     }
     
-    private async Task NotifyClientsOfGameState(Room room, User player, Turn turn)
+    private async Task NotifyClientsOfGameState(User player, Turn turn)
     {
         await Me.NotifyTurnProcessed();
-        await Me.RemoveCardRangeFromHand(turn.Delta.Cards);
-        await Hands(room.Game.HandsExceptPlayerId(CurrentPlayerId)).RemoveCardsFromPlayerHand(player.ToData(), turn.Delta.Cards.Count);
-        await Everyone.AddCardRangeToPile(turn.Delta.Cards);
+        await Everyone.MoveCardsFromHandToPile(player.ToData(), turn.Delta.Cards);
     }
 
     private async Task EnsurePendingCardsPicked(Room room)

--- a/src/Karata.Server/Services/TurnProcessingService.cs
+++ b/src/Karata.Server/Services/TurnProcessingService.cs
@@ -152,10 +152,9 @@ public class TurnProcessingService(
         room.Game.Pick = 0;
         room.Game.CurrentHand.Cards.AddRange(dealt);
         
-        await Everyone.RemoveCardsFromDeck(dealt.Count);
-        await Me.AddCardRangeToHand(dealt);
+        await Me.MoveCardsFromDeckToHand(dealt);
         await Hands(room.Game.HandsExceptPlayerId(CurrentPlayerId))
-            .AddCardsToPlayerHand(room.Game.CurrentHand.Player.ToData(), dealt.Count);
+            .MoveCardCountFromDeckToHand(room.Game.CurrentHand.Player.ToData(), dealt.Count);
     }
 
     private async Task CheckRemainingCards(Room room, User player, Turn turn)


### PR DESCRIPTION
Combines individual actions involving cards like `RemoveCardsFromHand(hand, cards) + AddCardsToPile(cards)` into composite ones like `MoveCardsFromHandToPile(hand, cards)`.

This reduces network round trips and enables atomic updates and more consistent state - the entire operation happened or it didn't.